### PR TITLE
refactor: replace `superstruct` with `@metamask/superstruct` +  bump `@metamask/utils`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,9 @@
     "test": "jest && jest-it-up",
     "test:watch": "jest --watch"
   },
-  "resolutions": {
-    "superstruct@^1.0.3": "1.0.3"
-  },
   "dependencies": {
-    "@metamask/utils": "^8.4.0",
-    "superstruct": "1.0.3"
+    "@metamask/superstruct": "^3.1.0",
+    "@metamask/utils": "^9.0.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.0",

--- a/src/caip-types.ts
+++ b/src/caip-types.ts
@@ -1,5 +1,5 @@
-import type { Infer } from 'superstruct';
-import { is, string, pattern } from 'superstruct';
+import type { Infer } from '@metamask/superstruct';
+import { is, string, pattern } from '@metamask/superstruct';
 
 export const CAIP_ASSET_TYPE_REGEX =
   /^(?<chainId>(?<namespace>[-a-z0-9]{3,8}):(?<reference>[-_a-zA-Z0-9]{1,32}))\/(?<assetNamespace>[-a-z0-9]{3,8}):(?<assetReference>[-.%a-zA-Z0-9]{1,128})$/u;

--- a/src/rpc-handler.ts
+++ b/src/rpc-handler.ts
@@ -1,6 +1,6 @@
+import { assert } from '@metamask/superstruct';
 import { JsonRpcRequestStruct } from '@metamask/utils';
 import type { Json, JsonRpcRequest, CaipChainId } from '@metamask/utils';
-import { assert } from '@metamask/superstruct';
 
 import type { Chain } from './api';
 import { GetBalancesRequestStruct } from './rpc-types';

--- a/src/rpc-handler.ts
+++ b/src/rpc-handler.ts
@@ -1,6 +1,6 @@
 import { JsonRpcRequestStruct } from '@metamask/utils';
 import type { Json, JsonRpcRequest, CaipChainId } from '@metamask/utils';
-import { assert } from 'superstruct';
+import { assert } from '@metamask/superstruct';
 
 import type { Chain } from './api';
 import { GetBalancesRequestStruct } from './rpc-types';

--- a/src/rpc-types.ts
+++ b/src/rpc-types.ts
@@ -1,4 +1,3 @@
-import { CaipChainIdStruct } from '@metamask/utils';
 import type { Infer } from '@metamask/superstruct';
 import {
   record,
@@ -9,6 +8,7 @@ import {
   object,
   literal,
 } from '@metamask/superstruct';
+import { CaipChainIdStruct } from '@metamask/utils';
 
 import { CaipAssetTypeOrIdStruct } from './caip-types';
 import { StringNumberStruct } from './types';

--- a/src/rpc-types.ts
+++ b/src/rpc-types.ts
@@ -1,5 +1,5 @@
 import { CaipChainIdStruct } from '@metamask/utils';
-import type { Infer } from 'superstruct';
+import type { Infer } from '@metamask/superstruct';
 import {
   record,
   array,
@@ -8,7 +8,7 @@ import {
   number,
   object,
   literal,
-} from 'superstruct';
+} from '@metamask/superstruct';
 
 import { CaipAssetTypeOrIdStruct } from './caip-types';
 import { StringNumberStruct } from './types';

--- a/src/superstruct.ts
+++ b/src/superstruct.ts
@@ -1,5 +1,5 @@
-import type { Struct } from 'superstruct';
-import { define } from 'superstruct';
+import type { Struct } from '@metamask/superstruct';
+import { define } from '@metamask/superstruct';
 
 /**
  * Defines a new string-struct matching a regular expression.

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,4 +1,4 @@
-import { is } from 'superstruct';
+import { is } from '@metamask/superstruct';
 
 import { StringNumberStruct } from './types';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Infer } from 'superstruct';
+import type { Infer } from '@metamask/superstruct';
 
 import type { CaipAssetType } from './caip-types';
 import { definePattern } from './superstruct';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1100,7 +1100,8 @@ __metadata:
     "@metamask/eslint-config-jest": "npm:^12.1.0"
     "@metamask/eslint-config-nodejs": "npm:^12.1.0"
     "@metamask/eslint-config-typescript": "npm:^12.1.0"
-    "@metamask/utils": "npm:^8.4.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^9.0.0"
     "@types/jest": "npm:^28.1.6"
     "@types/node": "npm:^16"
     "@typescript-eslint/eslint-plugin": "npm:^5.43.0"
@@ -1119,7 +1120,6 @@ __metadata:
     jest-it-up: "npm:^2.0.2"
     prettier: "npm:^2.7.1"
     prettier-plugin-packagejson: "npm:^2.3.0"
-    superstruct: "npm:1.0.3"
     ts-jest: "npm:^28.0.7"
     ts-node: "npm:^10.7.0"
     tsup: "npm:^7.2.0"
@@ -1178,20 +1178,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^8.4.0":
-  version: 8.4.0
-  resolution: "@metamask/utils@npm:8.4.0"
+"@metamask/superstruct@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@metamask/superstruct@npm:3.1.0"
+  checksum: 10/5066fe228d5f11da387606d7f9545de2b473ab5a9e0f1bb8aea2f52d3e2c9d25e427151acde61f4a2de80a07a9871fe9505ad06abca6a61b7c3b54ed5c403b01
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@metamask/utils@npm:9.0.0"
   dependencies:
     "@ethereumjs/tx": "npm:^4.2.0"
+    "@metamask/superstruct": "npm:^3.1.0"
     "@noble/hashes": "npm:^1.3.1"
     "@scure/base": "npm:^1.1.3"
     "@types/debug": "npm:^4.1.7"
     debug: "npm:^4.3.4"
     pony-cause: "npm:^2.1.10"
     semver: "npm:^7.5.4"
-    superstruct: "npm:^1.0.3"
     uuid: "npm:^9.0.1"
-  checksum: 10/5ce14d4e1630bf9269ab3b5cf3e05f393776b806c5be10a503128a3bc1d3aee891465d1f3937f537fdecec355a202a99ab70ae74f9bd37d51d3730c98c8f3dfc
+  checksum: 10/04a4eaba79e166fc6d23ecdba8b60625235a3a8c81fa615de64b845e74fa099ea7afd031060206c24809cfa161e7bca5aeb0bfd26079c5cbb82cb37f6a55ddb2
   languageName: node
   linkType: hard
 
@@ -6325,13 +6332,6 @@ __metadata:
     sucrase: bin/sucrase
     sucrase-node: bin/sucrase-node
   checksum: 10/b64d154a7a7eaa4b39668c3124bd08cd505f683d36ac4fb94def6491fb3af155b24b6e41b55011e38582e7d59c440af79ffba8709f3da78aeedf2f07b6d51d84
-  languageName: node
-  linkType: hard
-
-"superstruct@npm:1.0.3":
-  version: 1.0.3
-  resolution: "superstruct@npm:1.0.3"
-  checksum: 10/632b6171ac136b6750e62a55f806cc949b3dbf2b4a7dc70cc85f54adcdf19d21eab9711f04e8a643b7dd622bbd8658366ead924f467adaccb2c8005c133b7976
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- Fixes `@metamask/chain-controller` regression caused by `@metamask/utils` bump to `9.0.0`:
  - Results in error due to conflicting `@metamask/utils` versions in dependency tree: [MetaMask/core/actions/runs/9720673645/job/26832389267?pr=3645#step:7:2370](https://github.com/MetaMask/core/actions/runs/9720673645/job/26832389267?pr=3645#step:7:2370)
- None of the exports that cause a breaking change in `@metamask/utils@9.0.0` (`getChecksumAddress`, `numberToHex`, `bigIntToHex`) are used in `@metamask/chain-api`, making this a patch update.
- Fixes incompatibility with downstream projects using `Node{16,Next}` `moduleResolution` option.

## Changelog

```md
## [0.1.1]

### Changed

- Bump `@metamask/utils` from `^8.4.0` to `^9.0.0`. ([#5](https://github.com/MetaMask/accounts-chain-api/pull/5))

### Fixed

- Replace `superstruct` with ESM-compatible `@metamask/superstruct` `^3.1.0`. ([#5](https://github.com/MetaMask/accounts-chain-api/pull/5))
  - This fixes the issue of this package being unusable by any TypeScript project that uses `Node16` or `NodeNext` as its `moduleResolution` option.
```
